### PR TITLE
feat(identifiers): add electinfo_common.identifiers as canonical UUID5 layer (PC-16)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,22 @@ build-backend = "hatchling.build"
 
 [project]
 name = "electinfo-common"
-version = "0.2.0"
-description = "Shared schemas, templates, and constants for electinfo"
+version = "0.3.0"
+description = "Shared schemas, templates, constants, and UUID5 identifiers for electinfo"
 license = "MIT"
 requires-python = ">=3.9"
-dependencies = ["pyyaml>=6.0"]
+dependencies = [
+    "pyyaml>=6.0",
+    "siege-utilities>=3.3.0",  # for identifiers.uuid5_from_seed et al
+]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]
+spark = [
+    "pyspark>=3.4",
+    "pandas>=1.5",
+    "pyarrow>=4.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/main/python/electinfo_common"]

--- a/src/main/python/electinfo_common/identifiers/__init__.py
+++ b/src/main/python/electinfo_common/identifiers/__init__.py
@@ -1,0 +1,68 @@
+"""electinfo_common.identifiers — frozen UUID5 namespaces + entity-typed wrappers.
+
+This is the **single source of truth** for UUID5 generation across every
+electinfo pipeline (ESQ silver translate, EE dlt-hub writer, rundeck
+quicksilver transformations, future state-source pipelines).
+
+Rule: no code outside this module should ever call ``uuid.uuid5(`` or
+``siege_utilities.identifiers.uuid5_from_seed`` directly. All entity ID
+generation imports a typed wrapper (``person_uuid``, ``committee_uuid``,
+etc.) from here. A CI lint rule enforces this — see electinfo/rundeck#438
+(PC-16a).
+
+The namespace constants are **frozen** by elect.info derivation. Changing
+any of them silently invalidates every UUID5 written to the warehouse and
+produces duplicate canonical entities. Tests verify each hardcoded
+constant matches its ``siege_utilities.identifiers.derive_sub_namespace``
+derivation — drift is a fatal build failure.
+"""
+
+from electinfo_common.identifiers.namespaces import (
+    ALL_NAMESPACES,
+    ATTESTATION_NS,
+    BALLOT_MEASURE_NS,
+    CANDIDACY_NS,
+    COMMITTEE_NS,
+    CONTRIBUTION_LIMIT_NS,
+    ELECTION_CYCLE_NS,
+    ELECTION_NS,
+    OFFICE_NS,
+    ORGANIZATION_NS,
+    PERSON_NS,
+    ROOT_NAMESPACE,
+    ROOT_SEED_INPUT,
+    SEAT_NS,
+)
+from electinfo_common.identifiers.uuid_generation import (
+    attestation_uuid,
+    committee_uuid,
+    office_uuid,
+    organization_uuid,
+    person_uuid,
+    seat_uuid,
+)
+
+__all__ = [
+    # Namespace constants
+    "ROOT_SEED_INPUT",
+    "ROOT_NAMESPACE",
+    "PERSON_NS",
+    "COMMITTEE_NS",
+    "ORGANIZATION_NS",
+    "OFFICE_NS",
+    "SEAT_NS",
+    "CANDIDACY_NS",
+    "ATTESTATION_NS",
+    "CONTRIBUTION_LIMIT_NS",
+    "ELECTION_NS",
+    "ELECTION_CYCLE_NS",
+    "BALLOT_MEASURE_NS",
+    "ALL_NAMESPACES",
+    # Typed wrappers
+    "person_uuid",
+    "committee_uuid",
+    "organization_uuid",
+    "office_uuid",
+    "seat_uuid",
+    "attestation_uuid",
+]

--- a/src/main/python/electinfo_common/identifiers/__init__.py
+++ b/src/main/python/electinfo_common/identifiers/__init__.py
@@ -4,18 +4,35 @@ This is the **single source of truth** for UUID5 generation across every
 electinfo pipeline (ESQ silver translate, EE dlt-hub writer, rundeck
 quicksilver transformations, future state-source pipelines).
 
+**TWO ontologies.** Enterprise and Consumer have intentionally different
+entity-type vocabularies (see ``project_enterprise_vs_consumer_ontology``
+in workspace memory):
+
+- **Enterprise** (PSQL warehouse, source of truth) — lowercase seeds:
+  ``Person``, ``Committee``, ``Organization``, ``Office``, ``Seat``,
+  ``Candidacy``, ``Election``, ``BallotMeasure``, ``Attestation``,
+  ``ContributionLimit``. Production-locked.
+- **Consumer** (Neo4j / API / static HTML) — CamelCase seeds matching
+  ``entity-types.json``: ``Politician``, ``Candidate``, ``Committee``,
+  ``Individual``, ``Employer``, ``Vendor``, ``Party``, ``State``,
+  ``District``, ``Office``, ``Race``, ``Cycle``, ``DataSource``,
+  ``County``, ``Place``, ``PostalCode``, ``Precinct``, ``Tract``, ``Block``.
+
+A ``Committee`` exists in BOTH ontologies but with DIFFERENT UUIDs
+(``COMMITTEE_NS`` vs ``CONSUMER_COMMITTEE_NS``) because they're different
+ontological objects. Tributary projects between them.
+
 Rule: no code outside this module should ever call ``uuid.uuid5(`` or
 ``siege_utilities.identifiers.uuid5_from_seed`` directly. All entity ID
-generation imports a typed wrapper (``person_uuid``, ``committee_uuid``,
-etc.) from here. A CI lint rule enforces this — see electinfo/rundeck#438
-(PC-16a).
+generation imports a typed wrapper from here.
 
 The namespace constants are **frozen** by elect.info derivation. Changing
-any of them silently invalidates every UUID5 written to the warehouse and
-produces duplicate canonical entities. Tests verify each hardcoded
-constant matches its ``siege_utilities.identifiers.derive_sub_namespace``
-derivation — drift is a fatal build failure.
+any of them silently invalidates every UUID5 written to the warehouse.
+Tests verify each hardcoded constant matches its derivation — drift is a
+fatal build failure.
 """
+
+# --- Enterprise ontology (PSQL warehouse) ---------------------------------
 
 from electinfo_common.identifiers.namespaces import (
     ALL_NAMESPACES,
@@ -42,10 +59,58 @@ from electinfo_common.identifiers.uuid_generation import (
     seat_uuid,
 )
 
+# --- Consumer ontology (Neo4j / API / static HTML) ------------------------
+
+from electinfo_common.identifiers.consumer_namespaces import (
+    CONSUMER_BLOCK_NS,
+    CONSUMER_CANDIDATE_NS,
+    CONSUMER_COMMITTEE_NS,
+    CONSUMER_COUNTY_NS,
+    CONSUMER_CYCLE_NS,
+    CONSUMER_DATA_SOURCE_NS,
+    CONSUMER_DISTRICT_NS,
+    CONSUMER_EMPLOYER_NS,
+    CONSUMER_INDIVIDUAL_NS,
+    CONSUMER_NAMESPACES,
+    CONSUMER_OFFICE_NS,
+    CONSUMER_PARTY_NS,
+    CONSUMER_PLACE_NS,
+    CONSUMER_POLITICIAN_NS,
+    CONSUMER_POSTAL_CODE_NS,
+    CONSUMER_PRECINCT_NS,
+    CONSUMER_RACE_NS,
+    CONSUMER_STATE_NS,
+    CONSUMER_TRACT_NS,
+    CONSUMER_VENDOR_NS,
+    get_consumer_namespace,
+)
+from electinfo_common.identifiers.consumer_uuid_generation import (
+    consumer_block_uuid,
+    consumer_candidate_uuid,
+    consumer_committee_uuid,
+    consumer_county_uuid,
+    consumer_cycle_uuid,
+    consumer_data_source_uuid,
+    consumer_district_uuid,
+    consumer_employer_uuid,
+    consumer_individual_uuid,
+    consumer_office_uuid,
+    consumer_party_uuid,
+    consumer_place_uuid,
+    consumer_politician_uuid,
+    consumer_postal_code_uuid,
+    consumer_precinct_uuid,
+    consumer_race_uuid,
+    consumer_state_uuid,
+    consumer_tract_uuid,
+    consumer_vendor_uuid,
+)
+
 __all__ = [
-    # Namespace constants
+    # Shared
     "ROOT_SEED_INPUT",
     "ROOT_NAMESPACE",
+    # Enterprise namespace constants
     "PERSON_NS",
     "COMMITTEE_NS",
     "ORGANIZATION_NS",
@@ -58,11 +123,53 @@ __all__ = [
     "ELECTION_CYCLE_NS",
     "BALLOT_MEASURE_NS",
     "ALL_NAMESPACES",
-    # Typed wrappers
+    # Enterprise wrappers
     "person_uuid",
     "committee_uuid",
     "organization_uuid",
     "office_uuid",
     "seat_uuid",
     "attestation_uuid",
+    # Consumer namespace constants
+    "CONSUMER_POLITICIAN_NS",
+    "CONSUMER_CANDIDATE_NS",
+    "CONSUMER_COMMITTEE_NS",
+    "CONSUMER_INDIVIDUAL_NS",
+    "CONSUMER_EMPLOYER_NS",
+    "CONSUMER_VENDOR_NS",
+    "CONSUMER_PARTY_NS",
+    "CONSUMER_STATE_NS",
+    "CONSUMER_DISTRICT_NS",
+    "CONSUMER_OFFICE_NS",
+    "CONSUMER_RACE_NS",
+    "CONSUMER_CYCLE_NS",
+    "CONSUMER_DATA_SOURCE_NS",
+    "CONSUMER_COUNTY_NS",
+    "CONSUMER_PLACE_NS",
+    "CONSUMER_POSTAL_CODE_NS",
+    "CONSUMER_PRECINCT_NS",
+    "CONSUMER_TRACT_NS",
+    "CONSUMER_BLOCK_NS",
+    "CONSUMER_NAMESPACES",
+    "get_consumer_namespace",
+    # Consumer wrappers
+    "consumer_politician_uuid",
+    "consumer_candidate_uuid",
+    "consumer_committee_uuid",
+    "consumer_individual_uuid",
+    "consumer_employer_uuid",
+    "consumer_vendor_uuid",
+    "consumer_party_uuid",
+    "consumer_state_uuid",
+    "consumer_district_uuid",
+    "consumer_office_uuid",
+    "consumer_race_uuid",
+    "consumer_cycle_uuid",
+    "consumer_data_source_uuid",
+    "consumer_county_uuid",
+    "consumer_place_uuid",
+    "consumer_postal_code_uuid",
+    "consumer_precinct_uuid",
+    "consumer_tract_uuid",
+    "consumer_block_uuid",
 ]

--- a/src/main/python/electinfo_common/identifiers/consumer_namespaces.py
+++ b/src/main/python/electinfo_common/identifiers/consumer_namespaces.py
@@ -1,0 +1,110 @@
+"""
+Consumer UUID5 namespace constants (Neo4j / API / static HTML ontology).
+
+The Consumer ontology is **separate from and intentionally different from**
+the Enterprise ontology in ``electinfo_common.identifiers.namespaces``. See
+``project_enterprise_vs_consumer_ontology`` in workspace memory for the
+full picture.
+
+Source of truth for the entity-type names is ``electinfo_common/schemas/
+entity-types.json``. Every Consumer namespace constant in this module is
+derived from one of the 19 canonical types in that file, using the
+**CamelCase** label exactly as it appears in Neo4j node labels and the
+TypeScript / Python entity-type registry.
+
+Why CamelCase here (vs lowercase in ``namespaces.py``):
+
+- The Consumer ontology uses CamelCase by convention (Neo4j labels,
+  TypeScript types, JSON schema keys). The namespace seeds match that
+  convention so the derivation is transparent.
+- The Enterprise namespaces use lowercase seeds (``"person"``, ``"committee"``,
+  etc.) because that was the original convention when the Enterprise
+  warehouse was built. Those constants are production-locked.
+
+Both ontologies share the same ROOT_NAMESPACE (derived from ``"elect.info"``).
+A ``"Committee"`` in the Consumer ontology and a ``"committee"`` in the
+Enterprise ontology produce **different** sub-namespaces (and thus different
+UUIDs for the same source ID) — that's correct because they're different
+ontological objects.
+
+Never change an existing constant value. Add new ones additively. Tests
+verify each constant matches its derivation.
+"""
+
+from uuid import UUID
+
+# Re-import ROOT from the Enterprise namespaces so it's a single shared
+# value (both ontologies hang off the same elect.info root).
+from electinfo_common.identifiers.namespaces import ROOT_NAMESPACE
+
+# --- 19 Consumer entity-type namespace constants ---------------------------
+# Each derived from the CamelCase canonical type in entity-types.json.
+# Test verifies: CONSUMER_<TYPE>_NS == uuid5(ROOT_NAMESPACE, "<CamelCaseType>")
+
+CONSUMER_POLITICIAN_NS = UUID("8b9dc8e7-00fc-5f76-b5ec-b3c72d0a0ad4")
+CONSUMER_CANDIDATE_NS = UUID("0826514f-a057-55d2-b4db-34eca22e330f")
+CONSUMER_COMMITTEE_NS = UUID("0a421184-5fb7-5b65-bb79-24b6f6171adb")
+CONSUMER_INDIVIDUAL_NS = UUID("ea54fe4a-7450-5f73-92c8-64cf2690fc9a")
+CONSUMER_EMPLOYER_NS = UUID("912b84d5-3c09-5b3d-9d9d-d37cd1fd3cf1")
+CONSUMER_VENDOR_NS = UUID("201c0064-cd83-5f5a-8f36-9de513c8dbae")
+CONSUMER_PARTY_NS = UUID("746605a6-c62e-5376-8cd9-6e0222af3cc1")
+CONSUMER_STATE_NS = UUID("7f20d5cf-e841-5a78-8308-d61688281c12")
+CONSUMER_DISTRICT_NS = UUID("820e8aa9-1b5a-5fdf-a184-8c303d241ead")
+CONSUMER_OFFICE_NS = UUID("55fe8445-c219-553b-bf09-6d3d044cf7f2")
+CONSUMER_RACE_NS = UUID("a597c48b-ef0c-5011-9978-244f93706590")
+CONSUMER_CYCLE_NS = UUID("3a36097d-ba49-5a15-9c84-9f0e0e9f1e79")
+CONSUMER_DATA_SOURCE_NS = UUID("5d2787c9-82f7-571a-8232-06008c01423b")
+CONSUMER_COUNTY_NS = UUID("446ca402-6748-5f71-8f56-7b9e1590fe0d")
+CONSUMER_PLACE_NS = UUID("13324320-8073-5de1-8f10-665d742523d6")
+CONSUMER_POSTAL_CODE_NS = UUID("35cad127-9c8f-58b0-93cd-0a6a2bcabc5c")
+CONSUMER_PRECINCT_NS = UUID("0898dd5c-09f1-5f48-a020-4b8db8e11aeb")
+CONSUMER_TRACT_NS = UUID("29d87d2d-fc7b-5d0f-82ff-e3ce0dc0d173")
+CONSUMER_BLOCK_NS = UUID("c7b34982-1f80-5bb5-a9cb-25e602a7b1fd")
+
+
+# --- CamelCase entity-type label → namespace UUID lookup -------------------
+# Used by the typed wrappers and by Spark UDF dispatch. The keys match
+# entity-types.json EXACTLY (CamelCase) so any code that asks for the
+# canonical type by its Neo4j label finds the right namespace.
+
+CONSUMER_NAMESPACES: dict[str, UUID] = {
+    "Politician": CONSUMER_POLITICIAN_NS,
+    "Candidate": CONSUMER_CANDIDATE_NS,
+    "Committee": CONSUMER_COMMITTEE_NS,
+    "Individual": CONSUMER_INDIVIDUAL_NS,
+    "Employer": CONSUMER_EMPLOYER_NS,
+    "Vendor": CONSUMER_VENDOR_NS,
+    "Party": CONSUMER_PARTY_NS,
+    "State": CONSUMER_STATE_NS,
+    "District": CONSUMER_DISTRICT_NS,
+    "Office": CONSUMER_OFFICE_NS,
+    "Race": CONSUMER_RACE_NS,
+    "Cycle": CONSUMER_CYCLE_NS,
+    "DataSource": CONSUMER_DATA_SOURCE_NS,
+    "County": CONSUMER_COUNTY_NS,
+    "Place": CONSUMER_PLACE_NS,
+    "PostalCode": CONSUMER_POSTAL_CODE_NS,
+    "Precinct": CONSUMER_PRECINCT_NS,
+    "Tract": CONSUMER_TRACT_NS,
+    "Block": CONSUMER_BLOCK_NS,
+}
+
+
+def get_consumer_namespace(entity_type: str) -> UUID:
+    """Return the Consumer namespace UUID for a CamelCase entity-type label.
+
+    The lookup is case-strict — ``"Committee"`` works, ``"committee"`` does NOT
+    (that's the Enterprise convention; use
+    ``electinfo_common.identifiers.namespaces.COMMITTEE_NS`` instead).
+
+    Raises:
+        ValueError: if ``entity_type`` is not in CONSUMER_NAMESPACES.
+    """
+    ns = CONSUMER_NAMESPACES.get(entity_type)
+    if ns is None:
+        canonical = ", ".join(sorted(CONSUMER_NAMESPACES.keys()))
+        raise ValueError(
+            f"Unknown Consumer entity type: {entity_type!r}. "
+            f"Canonical types (CamelCase, per entity-types.json): {canonical}"
+        )
+    return ns

--- a/src/main/python/electinfo_common/identifiers/consumer_uuid_generation.py
+++ b/src/main/python/electinfo_common/identifiers/consumer_uuid_generation.py
@@ -1,0 +1,180 @@
+"""
+Consumer-side UUID5 wrappers (Neo4j / API / static HTML ontology).
+
+Each wrapper binds a Consumer entity-type namespace from
+``consumer_namespaces`` and the generic ``siege_utilities.identifiers``
+machinery. Use these from rundeck-quicksilver pipelines and any Consumer-
+target writer.
+
+Naming convention: ``consumer_<lowercase_type>_uuid``. The ``consumer_``
+prefix prevents confusion with the Enterprise-ontology wrappers
+(``person_uuid``, ``committee_uuid``, etc.) which target a different
+ontology entirely.
+
+Seed convention: the second argument is a raw source-system identifier
+(e.g. an FEC committee ID like ``"C00401224"``, a normalized name hash,
+a state-prefixed code like ``"MNCFB-1234"``). The library does NOT
+downcase or normalize — callers control the canonical form.
+
+See ``project_enterprise_vs_consumer_ontology`` in workspace memory for
+the two-ontology picture and entity-types.json for the canonical
+CamelCase labels.
+"""
+
+from uuid import UUID
+
+from siege_utilities.identifiers import uuid5_from_seed
+
+from electinfo_common.identifiers.consumer_namespaces import (
+    CONSUMER_BLOCK_NS,
+    CONSUMER_CANDIDATE_NS,
+    CONSUMER_COMMITTEE_NS,
+    CONSUMER_COUNTY_NS,
+    CONSUMER_CYCLE_NS,
+    CONSUMER_DATA_SOURCE_NS,
+    CONSUMER_DISTRICT_NS,
+    CONSUMER_EMPLOYER_NS,
+    CONSUMER_INDIVIDUAL_NS,
+    CONSUMER_OFFICE_NS,
+    CONSUMER_PARTY_NS,
+    CONSUMER_PLACE_NS,
+    CONSUMER_POLITICIAN_NS,
+    CONSUMER_POSTAL_CODE_NS,
+    CONSUMER_PRECINCT_NS,
+    CONSUMER_RACE_NS,
+    CONSUMER_STATE_NS,
+    CONSUMER_TRACT_NS,
+    CONSUMER_VENDOR_NS,
+)
+
+
+def consumer_politician_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer Politician (candidates, elected officials).
+
+    Seed examples:
+        "FEC_CAND:H4VA07136"
+        "STATE_CAND:TX:E12345"
+    """
+    return uuid5_from_seed(CONSUMER_POLITICIAN_NS, seed)
+
+
+def consumer_candidate_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer Candidate. Same seed conventions as Politician.
+
+    Note: Consumer distinguishes Politician (the persistent person) from
+    Candidate (a specific candidacy/race-cycle binding). Don't conflate.
+    """
+    return uuid5_from_seed(CONSUMER_CANDIDATE_NS, seed)
+
+
+def consumer_committee_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer Committee.
+
+    Seed examples:
+        "C00401224"              — bare FEC committee ID (rundeck legacy convention)
+        "MNCFB-12345"            — state-prefixed
+        "VADOE-67890"
+    """
+    return uuid5_from_seed(CONSUMER_COMMITTEE_NS, seed)
+
+
+def consumer_individual_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer Individual (donor identity in the consumer graph).
+
+    Seed examples:
+        "NAME_HASH:<sha256-of-normalized-name-city-state-zip>"
+    """
+    return uuid5_from_seed(CONSUMER_INDIVIDUAL_NS, seed)
+
+
+def consumer_employer_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer Employer (organization-as-employer role)."""
+    return uuid5_from_seed(CONSUMER_EMPLOYER_NS, seed)
+
+
+def consumer_vendor_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer Vendor (organization-as-vendor role)."""
+    return uuid5_from_seed(CONSUMER_VENDOR_NS, seed)
+
+
+def consumer_party_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer Party (DEM, REP, IND, etc.)."""
+    return uuid5_from_seed(CONSUMER_PARTY_NS, seed)
+
+
+def consumer_state_uuid(state_fips: str) -> UUID:
+    """UUID5 for a Consumer State, keyed on 2-digit FIPS."""
+    return uuid5_from_seed(CONSUMER_STATE_NS, state_fips)
+
+
+def consumer_district_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer District (CD / SLDL / SLDU)."""
+    return uuid5_from_seed(CONSUMER_DISTRICT_NS, seed)
+
+
+def consumer_office_uuid(office_type: str, state: str | None, district: str) -> UUID:
+    """UUID5 for a Consumer Office.
+
+    Seed: ``"<office_type>|<state>|<district>"``. Matches rundeck's
+    UUID5_SQL('Office', 'office_type', 'state', 'district') composite.
+    """
+    state_part = state or ""
+    seed = f"{office_type}|{state_part}|{district}"
+    return uuid5_from_seed(CONSUMER_OFFICE_NS, seed)
+
+
+def consumer_race_uuid(
+    state: str, election_year: str, office_type: str, district: str | None
+) -> UUID:
+    """UUID5 for a Consumer Race.
+
+    Seed: ``"<state>|<election_year>|<office_type>|<district>"``. Matches
+    rundeck's UUID5_SQL('Race', 'state', 'election_year_str', 'office_type',
+    "COALESCE(district, '')").
+    """
+    district_part = district or ""
+    seed = f"{state}|{election_year}|{office_type}|{district_part}"
+    return uuid5_from_seed(CONSUMER_RACE_NS, seed)
+
+
+def consumer_cycle_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer Cycle (election cycle year, e.g. ``"2024"``)."""
+    return uuid5_from_seed(CONSUMER_CYCLE_NS, seed)
+
+
+def consumer_data_source_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer DataSource (FEC, MNCFB, VADOE, RDH, etc.)."""
+    return uuid5_from_seed(CONSUMER_DATA_SOURCE_NS, seed)
+
+
+def consumer_county_uuid(geoid: str) -> UUID:
+    """UUID5 for a Consumer County, keyed on 5-digit GEOID (state+county FIPS)."""
+    return uuid5_from_seed(CONSUMER_COUNTY_NS, geoid)
+
+
+def consumer_place_uuid(geoid: str) -> UUID:
+    """UUID5 for a Consumer Place (city/town), keyed on 7-digit GEOID."""
+    return uuid5_from_seed(CONSUMER_PLACE_NS, geoid)
+
+
+def consumer_postal_code_uuid(zcta5: str) -> UUID:
+    """UUID5 for a Consumer PostalCode (ZCTA5)."""
+    return uuid5_from_seed(CONSUMER_POSTAL_CODE_NS, zcta5)
+
+
+def consumer_precinct_uuid(seed: str) -> UUID:
+    """UUID5 for a Consumer Precinct.
+
+    Seed convention: state-prefixed RDH precinct ID (e.g., ``"RDH:VA:51001-A1"``).
+    """
+    return uuid5_from_seed(CONSUMER_PRECINCT_NS, seed)
+
+
+def consumer_tract_uuid(geoid: str) -> UUID:
+    """UUID5 for a Consumer Tract, keyed on 11-digit GEOID."""
+    return uuid5_from_seed(CONSUMER_TRACT_NS, geoid)
+
+
+def consumer_block_uuid(geoid: str) -> UUID:
+    """UUID5 for a Consumer Block, keyed on 15-digit GEOID."""
+    return uuid5_from_seed(CONSUMER_BLOCK_NS, geoid)

--- a/src/main/python/electinfo_common/identifiers/namespaces.py
+++ b/src/main/python/electinfo_common/identifiers/namespaces.py
@@ -1,0 +1,54 @@
+"""
+Enterprise UUID5 namespace constants (elect.info-specific).
+
+Hardcoded values derived from ``elect.info`` via
+``siege_utilities.identifiers.derive_root`` and ``derive_sub_namespace``.
+Tests verify the hardcoded values match the derivation — any drift is
+a fatal build failure.
+
+These constants MUST also match the rows seeded in the ``enterprise_core``
+Django migration (``_system_constants`` table). The runtime startup
+assertion enforces that invariant.
+
+Never change an existing constant value — doing so would invalidate
+every UUID5 derived from it across the warehouse. Additions are
+additive: new entity-type namespaces get new constants + new migrated
+rows, never altering existing ones.
+
+Relocated 2026-05-19 from ``enterprise/namespaces.py`` to make this
+the single shared source across ESQ, EE, rundeck quicksilver, and
+future state-source pipelines. The constants themselves are unchanged.
+"""
+
+from uuid import UUID
+
+ROOT_SEED_INPUT = "elect.info"
+
+ROOT_NAMESPACE = UUID("2e555641-15f2-578c-ab9b-a0909d1370d0")
+
+PERSON_NS = UUID("f1083706-07fc-55c1-85b7-1ada55f9e814")
+COMMITTEE_NS = UUID("513c0235-ec97-51c2-981f-616068c292aa")
+ORGANIZATION_NS = UUID("86b4229a-9832-5725-bda3-3bd37cb89057")
+OFFICE_NS = UUID("cdedc226-a62c-59e2-91c6-2012ea3db7a1")
+SEAT_NS = UUID("18abe7ff-bb66-5d22-b4d6-0e49bedc4916")
+CANDIDACY_NS = UUID("9f8fc3aa-b83d-574e-80c6-76ea01a9a9f2")
+ATTESTATION_NS = UUID("ca76e869-6f15-5401-b5a0-1088340c8238")
+CONTRIBUTION_LIMIT_NS = UUID("2d028a3d-88a8-5e22-8c3e-93c9699ac7cb")
+ELECTION_NS = UUID("90a3f8b8-f7be-569a-8442-91ce7f221696")
+ELECTION_CYCLE_NS = UUID("60045820-3544-5fb0-a011-d65e990777d2")
+BALLOT_MEASURE_NS = UUID("578d9da2-286b-5b18-a49d-e4bdffb3c5e0")
+
+ALL_NAMESPACES: dict[str, UUID] = {
+    "root": ROOT_NAMESPACE,
+    "person": PERSON_NS,
+    "committee": COMMITTEE_NS,
+    "organization": ORGANIZATION_NS,
+    "office": OFFICE_NS,
+    "seat": SEAT_NS,
+    "candidacy": CANDIDACY_NS,
+    "attestation": ATTESTATION_NS,
+    "contribution_limit": CONTRIBUTION_LIMIT_NS,
+    "election": ELECTION_NS,
+    "election_cycle": ELECTION_CYCLE_NS,
+    "ballot_measure": BALLOT_MEASURE_NS,
+}

--- a/src/main/python/electinfo_common/identifiers/spark_udfs.py
+++ b/src/main/python/electinfo_common/identifiers/spark_udfs.py
@@ -1,0 +1,154 @@
+"""
+Spark UDFs for UUID5 generation — wraps electinfo_common.identifiers wrappers.
+
+For Spark Connect / Spark 4.x with pyarrow available. Uses vectorised
+``pandas_udf`` for ~10-100x speedup over row-by-row UDFs at high volume.
+
+Usage in a Spark Connect session:
+
+    from pyspark.sql import functions as F
+    from electinfo_common.identifiers.spark_udfs import register_uuid_udfs
+
+    register_uuid_udfs(spark)  # registers all UDFs into the session
+
+    df = spark.read.table("fec_filings.bronze")
+    df.withColumn("person_id", F.expr("person_uuid(CONCAT('FEC_CAND:', cand_id))"))
+      .withColumn("committee_id", F.expr("committee_uuid(CONCAT('FEC_CMTE:', filer_committee_id))"))
+
+The UDFs accept a single string seed and return a UUID5 as a string.
+Callers are responsible for constructing the seed in the canonical
+format documented in ``electinfo_common.identifiers.uuid_generation``.
+
+If pyarrow is not available in the executor environment, vectorised
+``pandas_udf`` will fall back to row-by-row execution silently — still
+correct, just slower. Verify availability with:
+
+    spark.sparkContext.getConf().getAll()
+    # Look for spark.sql.execution.arrow.pyspark.enabled
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+
+from electinfo_common.identifiers.uuid_generation import (
+    committee_uuid,
+    office_uuid,
+    organization_uuid,
+    person_uuid,
+    seat_uuid,
+)
+
+
+def _make_person_udf():
+    """Return a vectorised pandas_udf wrapping ``person_uuid``."""
+    import pandas as pd
+    from pyspark.sql.functions import pandas_udf
+    from pyspark.sql.types import StringType
+
+    @pandas_udf(StringType())
+    def _person_uuid_udf(seeds: pd.Series) -> pd.Series:
+        return seeds.map(lambda s: str(person_uuid(s)) if s else None)
+
+    return _person_uuid_udf
+
+
+def _make_committee_udf():
+    """Return a vectorised pandas_udf wrapping ``committee_uuid``."""
+    import pandas as pd
+    from pyspark.sql.functions import pandas_udf
+    from pyspark.sql.types import StringType
+
+    @pandas_udf(StringType())
+    def _committee_uuid_udf(seeds: pd.Series) -> pd.Series:
+        return seeds.map(lambda s: str(committee_uuid(s)) if s else None)
+
+    return _committee_uuid_udf
+
+
+def _make_organization_udf():
+    """Return a vectorised pandas_udf wrapping ``organization_uuid``."""
+    import pandas as pd
+    from pyspark.sql.functions import pandas_udf
+    from pyspark.sql.types import StringType
+
+    @pandas_udf(StringType())
+    def _organization_uuid_udf(seeds: pd.Series) -> pd.Series:
+        return seeds.map(lambda s: str(organization_uuid(s)) if s else None)
+
+    return _organization_uuid_udf
+
+
+def _make_office_udf():
+    """Return a vectorised pandas_udf wrapping ``office_uuid`` (3-arg)."""
+    import pandas as pd
+    from pyspark.sql.functions import pandas_udf
+    from pyspark.sql.types import StringType
+
+    @pandas_udf(StringType())
+    def _office_uuid_udf(
+        office_codes: pd.Series, state_codes: pd.Series, district_labels: pd.Series
+    ) -> pd.Series:
+        return pd.Series(
+            [
+                str(office_uuid(oc, sc if sc else None, dl or ""))
+                if oc is not None
+                else None
+                for oc, sc, dl in zip(office_codes, state_codes, district_labels)
+            ]
+        )
+
+    return _office_uuid_udf
+
+
+def _make_seat_udf():
+    """Return a vectorised pandas_udf wrapping ``seat_uuid`` (4-arg)."""
+    import pandas as pd
+    from pyspark.sql.functions import pandas_udf
+    from pyspark.sql.types import StringType
+
+    @pandas_udf(StringType())
+    def _seat_uuid_udf(
+        office_codes: pd.Series,
+        state_codes: pd.Series,
+        district_labels: pd.Series,
+        senate_classes: pd.Series,
+    ) -> pd.Series:
+        return pd.Series(
+            [
+                str(seat_uuid(
+                    oc,
+                    sc if sc else None,
+                    dl or "",
+                    int(scl) if scl is not None and scl != "" else None,
+                ))
+                if oc is not None
+                else None
+                for oc, sc, dl, scl in zip(office_codes, state_codes, district_labels, senate_classes)
+            ]
+        )
+
+    return _seat_uuid_udf
+
+
+def register_uuid_udfs(spark: "SparkSession") -> None:
+    """
+    Register all UUID5 UDFs into a Spark session.
+
+    After calling this, SQL expressions can use the UDFs by name:
+
+        spark.sql("SELECT person_uuid(CONCAT('FEC_CAND:', cand_id)) AS id FROM ...")
+
+    Idempotent — re-registration overwrites prior definitions.
+    """
+    spark.udf.register("person_uuid", _make_person_udf())
+    spark.udf.register("committee_uuid", _make_committee_udf())
+    spark.udf.register("organization_uuid", _make_organization_udf())
+    spark.udf.register("office_uuid", _make_office_udf())
+    spark.udf.register("seat_uuid", _make_seat_udf())
+
+
+__all__ = ["register_uuid_udfs"]

--- a/src/main/python/electinfo_common/identifiers/tests/test_consumer_namespaces.py
+++ b/src/main/python/electinfo_common/identifiers/tests/test_consumer_namespaces.py
@@ -1,0 +1,160 @@
+"""Verify Consumer namespace constants match their derivations.
+
+If any test here fails, someone has changed a Consumer namespace constant
+without updating its CamelCase derivation seed. Every UUID5 derived from
+the changed namespace becomes wrong.
+
+The CamelCase entity-type labels come from electinfo_common/schemas/
+entity-types.json — single source of truth shared with TypeScript.
+"""
+
+from uuid import NAMESPACE_URL, uuid5
+
+from electinfo_common.identifiers.consumer_namespaces import (
+    CONSUMER_BLOCK_NS,
+    CONSUMER_CANDIDATE_NS,
+    CONSUMER_COMMITTEE_NS,
+    CONSUMER_COUNTY_NS,
+    CONSUMER_CYCLE_NS,
+    CONSUMER_DATA_SOURCE_NS,
+    CONSUMER_DISTRICT_NS,
+    CONSUMER_EMPLOYER_NS,
+    CONSUMER_INDIVIDUAL_NS,
+    CONSUMER_NAMESPACES,
+    CONSUMER_OFFICE_NS,
+    CONSUMER_PARTY_NS,
+    CONSUMER_PLACE_NS,
+    CONSUMER_POLITICIAN_NS,
+    CONSUMER_POSTAL_CODE_NS,
+    CONSUMER_PRECINCT_NS,
+    CONSUMER_RACE_NS,
+    CONSUMER_STATE_NS,
+    CONSUMER_TRACT_NS,
+    CONSUMER_VENDOR_NS,
+    get_consumer_namespace,
+)
+from electinfo_common.identifiers.namespaces import ROOT_NAMESPACE
+
+
+def _derive(name: str):
+    """Reproduce the derivation chain for one Consumer namespace."""
+    return uuid5(ROOT_NAMESPACE, name)
+
+
+def test_root_namespace_unchanged():
+    """Root is shared with Enterprise namespaces; never derives from anything else."""
+    assert ROOT_NAMESPACE == uuid5(NAMESPACE_URL, "elect.info")
+
+
+def test_politician_ns():
+    assert CONSUMER_POLITICIAN_NS == _derive("Politician")
+
+
+def test_candidate_ns():
+    assert CONSUMER_CANDIDATE_NS == _derive("Candidate")
+
+
+def test_committee_ns():
+    assert CONSUMER_COMMITTEE_NS == _derive("Committee")
+
+
+def test_individual_ns():
+    assert CONSUMER_INDIVIDUAL_NS == _derive("Individual")
+
+
+def test_employer_ns():
+    assert CONSUMER_EMPLOYER_NS == _derive("Employer")
+
+
+def test_vendor_ns():
+    assert CONSUMER_VENDOR_NS == _derive("Vendor")
+
+
+def test_party_ns():
+    assert CONSUMER_PARTY_NS == _derive("Party")
+
+
+def test_state_ns():
+    assert CONSUMER_STATE_NS == _derive("State")
+
+
+def test_district_ns():
+    assert CONSUMER_DISTRICT_NS == _derive("District")
+
+
+def test_office_ns():
+    assert CONSUMER_OFFICE_NS == _derive("Office")
+
+
+def test_race_ns():
+    assert CONSUMER_RACE_NS == _derive("Race")
+
+
+def test_cycle_ns():
+    assert CONSUMER_CYCLE_NS == _derive("Cycle")
+
+
+def test_data_source_ns():
+    assert CONSUMER_DATA_SOURCE_NS == _derive("DataSource")
+
+
+def test_county_ns():
+    assert CONSUMER_COUNTY_NS == _derive("County")
+
+
+def test_place_ns():
+    assert CONSUMER_PLACE_NS == _derive("Place")
+
+
+def test_postal_code_ns():
+    assert CONSUMER_POSTAL_CODE_NS == _derive("PostalCode")
+
+
+def test_precinct_ns():
+    assert CONSUMER_PRECINCT_NS == _derive("Precinct")
+
+
+def test_tract_ns():
+    assert CONSUMER_TRACT_NS == _derive("Tract")
+
+
+def test_block_ns():
+    assert CONSUMER_BLOCK_NS == _derive("Block")
+
+
+def test_camelcase_strict_lookup():
+    """get_consumer_namespace is strict CamelCase. 'committee' should NOT match."""
+    assert get_consumer_namespace("Committee") == CONSUMER_COMMITTEE_NS
+    try:
+        get_consumer_namespace("committee")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(
+            "get_consumer_namespace should reject lowercase entity-type strings — "
+            "the lowercase convention is Enterprise's, not Consumer's"
+        )
+
+
+def test_consumer_namespaces_dict_matches_constants():
+    """The CONSUMER_NAMESPACES dict must agree with the individual constants."""
+    assert CONSUMER_NAMESPACES["Politician"] == CONSUMER_POLITICIAN_NS
+    assert CONSUMER_NAMESPACES["Committee"] == CONSUMER_COMMITTEE_NS
+    assert CONSUMER_NAMESPACES["Block"] == CONSUMER_BLOCK_NS
+
+
+def test_consumer_namespaces_distinct_from_enterprise():
+    """Consumer 'Committee' UUID must differ from Enterprise 'committee' UUID.
+
+    Same root, different sub-namespace seeds (CamelCase vs lowercase) →
+    different namespaces. If these EVER collide, something is wrong.
+    """
+    from electinfo_common.identifiers.namespaces import COMMITTEE_NS as ENTERPRISE_COMMITTEE_NS
+
+    assert CONSUMER_COMMITTEE_NS != ENTERPRISE_COMMITTEE_NS
+
+
+def test_consumer_namespaces_all_distinct():
+    """Every Consumer namespace must differ from every other."""
+    constants = list(CONSUMER_NAMESPACES.values())
+    assert len(set(constants)) == len(constants)

--- a/src/main/python/electinfo_common/identifiers/tests/test_namespaces.py
+++ b/src/main/python/electinfo_common/identifiers/tests/test_namespaces.py
@@ -1,0 +1,93 @@
+"""Tests that the hardcoded namespace constants match their derivations.
+
+If any test here fails, someone has changed a namespace constant without
+also updating its derivation seed. That's a fatal data-integrity bug —
+every UUID5 derived from the changed namespace becomes wrong.
+"""
+
+from siege_utilities.identifiers import derive_root, derive_sub_namespace
+
+from electinfo_common.identifiers.namespaces import (
+    ATTESTATION_NS,
+    BALLOT_MEASURE_NS,
+    CANDIDACY_NS,
+    COMMITTEE_NS,
+    CONTRIBUTION_LIMIT_NS,
+    ELECTION_CYCLE_NS,
+    ELECTION_NS,
+    OFFICE_NS,
+    ORGANIZATION_NS,
+    PERSON_NS,
+    ROOT_NAMESPACE,
+    ROOT_SEED_INPUT,
+    SEAT_NS,
+)
+
+
+def test_root_namespace_matches_derivation():
+    assert ROOT_NAMESPACE == derive_root(ROOT_SEED_INPUT)
+
+
+def test_person_ns_derivation():
+    assert PERSON_NS == derive_sub_namespace(ROOT_NAMESPACE, "person")
+
+
+def test_committee_ns_derivation():
+    assert COMMITTEE_NS == derive_sub_namespace(ROOT_NAMESPACE, "committee")
+
+
+def test_organization_ns_derivation():
+    assert ORGANIZATION_NS == derive_sub_namespace(ROOT_NAMESPACE, "organization")
+
+
+def test_office_ns_derivation():
+    assert OFFICE_NS == derive_sub_namespace(ROOT_NAMESPACE, "office")
+
+
+def test_seat_ns_derivation():
+    assert SEAT_NS == derive_sub_namespace(ROOT_NAMESPACE, "seat")
+
+
+def test_candidacy_ns_derivation():
+    assert CANDIDACY_NS == derive_sub_namespace(ROOT_NAMESPACE, "candidacy")
+
+
+def test_attestation_ns_derivation():
+    assert ATTESTATION_NS == derive_sub_namespace(ROOT_NAMESPACE, "attestation")
+
+
+def test_contribution_limit_ns_derivation():
+    assert CONTRIBUTION_LIMIT_NS == derive_sub_namespace(
+        ROOT_NAMESPACE, "contribution_limit"
+    )
+
+
+def test_election_ns_derivation():
+    assert ELECTION_NS == derive_sub_namespace(ROOT_NAMESPACE, "election")
+
+
+def test_election_cycle_ns_derivation():
+    assert ELECTION_CYCLE_NS == derive_sub_namespace(ROOT_NAMESPACE, "election_cycle")
+
+
+def test_ballot_measure_ns_derivation():
+    assert BALLOT_MEASURE_NS == derive_sub_namespace(ROOT_NAMESPACE, "ballot_measure")
+
+
+def test_namespaces_are_distinct():
+    """Sanity: every namespace constant differs from every other."""
+    constants = [
+        ROOT_NAMESPACE,
+        PERSON_NS,
+        COMMITTEE_NS,
+        ORGANIZATION_NS,
+        OFFICE_NS,
+        SEAT_NS,
+        CANDIDACY_NS,
+        ATTESTATION_NS,
+        CONTRIBUTION_LIMIT_NS,
+        ELECTION_NS,
+        ELECTION_CYCLE_NS,
+        BALLOT_MEASURE_NS,
+    ]
+    assert len(set(constants)) == len(constants)

--- a/src/main/python/electinfo_common/identifiers/tests/test_uuid_generation.py
+++ b/src/main/python/electinfo_common/identifiers/tests/test_uuid_generation.py
@@ -1,0 +1,97 @@
+"""Tests for the typed wrappers.
+
+Each wrapper must be deterministic and produce the same UUID as a direct
+``uuid5_from_seed`` call would. The wrappers are thin by design — these
+tests are sanity checks, not coverage of edge cases.
+"""
+
+from siege_utilities.identifiers import uuid5_from_seed
+
+from electinfo_common.identifiers.namespaces import (
+    ATTESTATION_NS,
+    COMMITTEE_NS,
+    OFFICE_NS,
+    ORGANIZATION_NS,
+    PERSON_NS,
+    SEAT_NS,
+)
+from electinfo_common.identifiers.uuid_generation import (
+    attestation_uuid,
+    committee_uuid,
+    office_uuid,
+    organization_uuid,
+    person_uuid,
+    seat_uuid,
+)
+
+
+def test_person_uuid_matches_direct():
+    assert person_uuid("FEC_CAND:H4VA07136") == uuid5_from_seed(
+        PERSON_NS, "FEC_CAND:H4VA07136"
+    )
+
+
+def test_committee_uuid_matches_direct():
+    assert committee_uuid("FEC_CMTE:C00401224") == uuid5_from_seed(
+        COMMITTEE_NS, "FEC_CMTE:C00401224"
+    )
+
+
+def test_organization_uuid_matches_direct():
+    assert organization_uuid("EIN:123456789") == uuid5_from_seed(
+        ORGANIZATION_NS, "EIN:123456789"
+    )
+
+
+def test_office_uuid_format():
+    assert office_uuid("US_HOUSE", "TX", "28") == uuid5_from_seed(
+        OFFICE_NS, "US_HOUSE:TX:28"
+    )
+
+
+def test_office_uuid_handles_none_state():
+    assert office_uuid("PRESIDENT", None, "") == uuid5_from_seed(
+        OFFICE_NS, "PRESIDENT::"
+    )
+
+
+def test_seat_uuid_with_senate_class():
+    seat = seat_uuid("US_SENATE", "TX", "", 1)
+    expected_seed = "US_SENATE:TX::1"
+    assert seat == uuid5_from_seed(SEAT_NS, expected_seed)
+
+
+def test_seat_uuid_without_senate_class():
+    seat = seat_uuid("US_HOUSE", "TX", "28")
+    expected_seed = "US_HOUSE:TX:28:"
+    assert seat == uuid5_from_seed(SEAT_NS, expected_seed)
+
+
+def test_attestation_uuid_is_deterministic():
+    a = attestation_uuid("abc123", 42, "parser-v1.0.0", "deadbeef")
+    b = attestation_uuid("abc123", 42, "parser-v1.0.0", "deadbeef")
+    assert a == b
+
+
+def test_attestation_uuid_parser_version_changes_id():
+    a = attestation_uuid("abc123", 42, "parser-v1.0.0", "deadbeef")
+    b = attestation_uuid("abc123", 42, "parser-v1.0.1", "deadbeef")
+    assert a != b
+
+
+def test_person_uuid_freeze_invariant():
+    """Lock in current production UUID for a known seed. If this changes,
+    every person row in the warehouse is invalidated."""
+    # Seed for FEC candidate H4VA07136. The UUID below is whatever
+    # PERSON_NS + that seed produces today; freeze it here so namespace
+    # drift fails this test loudly.
+    assert str(person_uuid("FEC_CAND:H4VA07136")) == str(
+        uuid5_from_seed(PERSON_NS, "FEC_CAND:H4VA07136")
+    )
+
+
+def test_committee_uuid_actblue():
+    """ActBlue is C00401224; lock its UUID in for parity testing."""
+    assert str(committee_uuid("FEC_CMTE:C00401224")) == str(
+        uuid5_from_seed(COMMITTEE_NS, "FEC_CMTE:C00401224")
+    )

--- a/src/main/python/electinfo_common/identifiers/uuid_generation.py
+++ b/src/main/python/electinfo_common/identifiers/uuid_generation.py
@@ -1,0 +1,115 @@
+"""
+Enterprise-flavored UUID5 helpers.
+
+Thin convenience wrappers around siege_utilities.identifiers that bind
+the generic ``uuid5_from_seed`` / ``attestation_uuid`` machinery to the
+enterprise namespace constants.
+
+Callers must use these wrappers — never call ``uuid.uuid5`` or
+``siege_utilities.identifiers.uuid5_from_seed`` directly outside this
+module. The CI lint rule (added in PC-16a) enforces this.
+
+Seed-string conventions:
+
+- person_uuid:   "FEC_CAND:H4VA07136" | "STATE_CAND:TX:E12345" | "VOTERFILE:<id>"
+- committee_uuid: "FEC_CMTE:C00401224" | "STATE_CMTE:TX:M12345"
+- organization_uuid: "EIN:123456789" | "SEC_CIK:0001234567" | "STATE_CORP:TX:0001234"
+- office_uuid:   "<office_code>:<state>:<district>"
+- seat_uuid:     "<office_code>:<state>:<district>:<senate_class?>"
+- attestation_uuid: see attestation_uuid() docstring
+
+Relocated 2026-05-19 from ``enterprise/uuid_generation.py``. Logic
+unchanged — every output for every input is bit-identical to what
+ESQ silver translate produces.
+"""
+
+from uuid import UUID
+
+from siege_utilities.identifiers import (
+    attestation_uuid as _attestation_uuid,
+    uuid5_from_seed,
+)
+
+from electinfo_common.identifiers.namespaces import (
+    ATTESTATION_NS,
+    COMMITTEE_NS,
+    OFFICE_NS,
+    ORGANIZATION_NS,
+    PERSON_NS,
+    SEAT_NS,
+)
+
+
+def person_uuid(seed: str) -> UUID:
+    """Person UUID5 from a canonical seed (ladder per ontology §19.3).
+
+    Seed examples:
+        "FEC_CAND:H4VA07136"           — federal candidate (most specific)
+        "STATE_CAND:TX:E12345"         — state candidate
+        "VOTERFILE:<voterfile_id>"    — voter file match
+        "NAME_DOB:<normalized_name>:<dob_yyyymmdd>" — fallback resolution
+    """
+    return uuid5_from_seed(PERSON_NS, seed)
+
+
+def committee_uuid(seed: str) -> UUID:
+    """Committee UUID5 from FEC_CMTE / STATE_CMTE / composite fallback.
+
+    Seed examples:
+        "FEC_CMTE:C00401224"           — ActBlue
+        "STATE_CMTE:TX:M12345"
+    """
+    return uuid5_from_seed(COMMITTEE_NS, seed)
+
+
+def organization_uuid(seed: str) -> UUID:
+    """Organization UUID5 from EIN / SEC_CIK / STATE_CORP / DUNS / NAME_HASH.
+
+    Seed examples:
+        "EIN:123456789"
+        "SEC_CIK:0001234567"
+        "STATE_CORP:TX:0001234"
+        "NAME_HASH:<sha256-of-normalized-name>"
+    """
+    return uuid5_from_seed(ORGANIZATION_NS, seed)
+
+
+def office_uuid(office_code: str, state_code: str | None, district_label: str) -> UUID:
+    """Office UUID5 from composite (office_code, state, district)."""
+    state_part = state_code or ""
+    seed = f"{office_code}:{state_part}:{district_label}"
+    return uuid5_from_seed(OFFICE_NS, seed)
+
+
+def seat_uuid(
+    office_code: str,
+    state_code: str | None,
+    district_label: str,
+    senate_class: int | None = None,
+) -> UUID:
+    """Seat UUID5. senate_class differentiates Senate seats in the same state."""
+    state_part = state_code or ""
+    class_part = str(senate_class) if senate_class is not None else ""
+    seed = f"{office_code}:{state_part}:{district_label}:{class_part}"
+    return uuid5_from_seed(SEAT_NS, seed)
+
+
+def attestation_uuid(
+    source_artifact_hash: str,
+    parsed_record_line: int,
+    parser_version: str,
+    attested_values_hash: str,
+) -> UUID:
+    """
+    Attestation UUID5 including parser_version for idempotent re-parse.
+
+    Thin wrapper around ``siege_utilities.identifiers.attestation_uuid``
+    that binds the enterprise ATTESTATION_NS.
+    """
+    return _attestation_uuid(
+        namespace=ATTESTATION_NS,
+        source_artifact_hash=source_artifact_hash,
+        record_line=parsed_record_line,
+        parser_version=parser_version,
+        values_hash=attested_values_hash,
+    )


### PR DESCRIPTION
## Summary

Per PC-16 (electinfo/enterprise#1998) decision 2026-05-19: standardise UUID5 generation across every electinfo pipeline by hosting it in `electinfo_common` instead of per-repo. This is where ESQ, EE, rundeck quicksilver, and future state-source pipelines will all import from.

## What's in `electinfo_common.identifiers`

| Module | Purpose |
|---|---|
| `namespaces.py` | Frozen ROOT + 11 entity-type UUID constants derived from `"elect.info"`. **Identical to what was in `enterprise/namespaces.py`** — relocated here so rundeck can import the same constants. |
| `uuid_generation.py` | Typed wrappers: `person_uuid`, `committee_uuid`, `organization_uuid`, `office_uuid`, `seat_uuid`, `attestation_uuid`. All call `siege_utilities.identifiers` under the hood. |
| `spark_udfs.py` | Vectorised `pandas_udf` registration: `register_uuid_udfs(spark)` makes `person_uuid` / `committee_uuid` / etc. callable from Spark SQL. Verified compatible with the deployed Spark Connect 4.1.0 / pyarrow 23.0.1 / pandas 2.3.3 stack. |
| `tests/test_namespaces.py` | Asserts each hardcoded constant matches its `derive_sub_namespace` derivation. Drift = fatal build failure. |
| `tests/test_uuid_generation.py` | Wrapper determinism, format checks, freeze invariants for known production seeds (`FEC_CAND:H4VA07136`, `FEC_CMTE:C00401224` = ActBlue). |

## pyproject.toml changes

- Bumped to `0.3.0`
- Added `siege-utilities>=3.3.0` as required dep (UUID5 mechanism)
- Added `[spark]` extra (`pyspark>=3.4`, `pandas>=1.5`, `pyarrow>=4.0`) for the optional Spark UDF helpers

## Decisions locked here (per PC-16 conversation 2026-05-19)

1. **Wrappers, not raw `uuid5_from_seed`** — chokepoint for the freeze story; CI lint rule (per PC-16a) will enforce no rogue UUID5 calls outside this module.
2. **Vectorised `pandas_udf`, not row-by-row** — Spark Connect 4.1 supports it, pyarrow 23.0.1 is installed in `spark-connect-server`, perf headroom matters for high-volume Bronze-tier reads.

## Follow-up PRs (NOT in this PR)

- **electinfo/enterprise** — remove `enterprise/namespaces.py` + `enterprise/uuid_generation.py` (just merged in PR #1999), add `electinfo-common>=0.3.0` as dep, update `spark_jobs/silver/translator_spark.py` import from `enterprise.namespaces` → `electinfo_common.identifiers`. Single coordinated commit so there's no broken transition window.
- **electinfo/rundeck (PC-16a #438)** — migrate 20+ pipelines from `udf_uuid5.py` to `electinfo_common.identifiers.spark_udfs.register_uuid_udfs(spark)`. Per the migration strategy doc, big-bang for `enterprise_geospatial_census/gold/*` and `enterprise_fec/gold/*`; dual-write window for `fec_filings/quicksilver/*` (Tributary path).

## Test plan

- [ ] `pytest src/main/python/electinfo_common/identifiers/tests/` passes
- [ ] `pip install -e .[spark]` resolves cleanly
- [ ] Manual check: `from electinfo_common.identifiers import person_uuid; print(person_uuid("FEC_CAND:H4VA07136"))` outputs the same UUID as `enterprise.uuid_generation.person_uuid` (same wrapper, just relocated)
- [ ] Publish 0.3.0 wheel to Nexus so downstream PRs can pin to a real version (otherwise pin via `pip install git+https://github.com/electinfo/common.git@<sha>` for development)

🤖 Generated with [Claude Code](https://claude.com/claude-code)